### PR TITLE
Doc improvements: simplify Python code, show shell one-liner alternative

### DIFF
--- a/pastebin/templates/about.html
+++ b/pastebin/templates/about.html
@@ -27,6 +27,10 @@ if __name__ == '__main__':
 
 <p>Save this script in <code>/usr/local/bin/dpaste</code> and <code>chmod +x ..filepath</code>.</p>
 <p>Usage: <code>cat foo.txt | dpaste</code></p>
+
+<p>Or you could use <code>curl</code>:
+<code>alias dpaste="curl -F 'content=&lt;-' http://dpaste.de/api/</code></p>
+
 {% endblock %}
 
 


### PR DESCRIPTION
As discussed via email.

I haven't tried to run the app locally to make sure I haven't messed up the markup.

I haven't tested the new Python code either, but I have successfully used `sys.stdin.read()` in my own scripts to slurp multiline text blobs before.
