### PR TITLE
Switch to django-appconf.

### DIFF
--- a/dpaste/conf.py
+++ b/dpaste/conf.py
@@ -1,0 +1,38 @@
+"""Default settings for dpaste."""
+
+from django.conf import settings
+from django.utils.translation import ugettext_lazy as _
+
+import appconf
+from . import enums
+
+
+class DPasteConf(appconf.AppConf):
+    class Meta:
+        prefix = 'dpaste'
+
+    BASE_URL = 'https://dpaste.de'
+
+    # Expiry
+    EXPIRE_CHOICES = (
+        (enums.EXPIRE_ONETIME, _(u'One Time Snippet')),
+        (enums.EXPIRE_ONE_HOUR, _(u'In one hour')),
+        (enums.EXPIRE_ONE_WEEK, _(u'In one week')),
+        (enums.EXPIRE_ONE_MONTH, _(u'In one month')),
+        # ('never', _(u'Never')),
+    )
+    EXPIRE_DEFAULT = enums.EXPIRE_ONE_MONTH
+
+    # Lexer
+    LEXER_DEFAULT = 'python'
+    LEXER_LIST = enums.DEFAULT_LEXER_LIST
+    LEXER_WORDWRAP = ('text', 'rst')
+
+    # Snippets
+    SLUG_LENGTH = 4
+    SLUG_CHOICES = 'abcdefghijkmnopqrstuvwxyzABCDEFGHJKLMNOPQRSTUVWXYZ1234567890'
+    MAX_CONTENT_LENGTH = 250 * 1024 * 1024
+
+    # Users
+    MAX_SNIPPETS_PER_USER = 15
+    ONETIME_LIMIT = 2

--- a/dpaste/enums.py
+++ b/dpaste/enums.py
@@ -1,0 +1,95 @@
+EXPIRE_ONETIME = 'onetime'
+EXPIRE_ONE_HOUR = 3600
+EXPIRE_ONE_WEEK = 3600 * 24 * 7
+EXPIRE_ONE_MONTH = 3600 * 24 * 30
+
+
+# Get a list of all lexer, and then remove all lexer which have '-' or '+'
+# or 'with' in the name. Those are too specific and never used. This produces a
+# tuple list of [(lexer, Lexer Display Name) ...] lexers.
+#  >>> from pygments.lexers import get_all_lexers
+#  >>> ALL_LEXER = set([(i[1][0], i[0]) for i in get_all_lexers()])
+#  >>> LEXER_LIST = [l for l in ALL_LEXER if not (
+#  >>>        '-' in l[0]
+#  >>>     or '+' in l[0]
+#  >>>     or '+' in l[1]
+#  >>>     or 'with' in l[1].lower()
+#  >>>     or ' ' in l[1]
+#  >>>     or l[0] in IGNORE_LEXER
+#  >>> )]
+#  >>> LEXER_LIST = sorted(LEXER_LIST)
+
+# The list of lexers. Its not worth to autogenerate this. See above how to
+# retrieve this.
+DEFAULT_LEXER_LIST = (
+    ('text', 'Text'),
+    ('text', '----------'),
+    ('abap', 'ABAP'),
+    ('apacheconf', 'ApacheConf'),
+    ('applescript', 'AppleScript'),
+    ('as', 'ActionScript'),
+    ('bash', 'Bash'),
+    ('bbcode', 'BBCode'),
+    ('c', 'C'),
+    ('clojure', 'Clojure'),
+    ('cobol', 'COBOL'),
+    ('css', 'CSS'),
+    ('cuda', 'CUDA'),
+    ('dart', 'Dart'),
+    ('delphi', 'Delphi'),
+    ('diff', 'Diff'),
+    ('django', 'Django'),
+    ('erlang', 'Erlang'),
+    ('fortran', 'Fortran'),
+    ('go', 'Go'),
+    ('groovy', 'Groovy'),
+    ('haml', 'Haml'),
+    ('haskell', 'Haskell'),
+    ('html', 'HTML'),
+    ('http', 'HTTP'),
+    ('ini', 'INI'),
+    ('irc', 'IRC'),
+    ('java', 'Java'),
+    ('js', 'JavaScript'),
+    ('json', 'JSON'),
+    ('lua', 'Lua'),
+    ('make', 'Makefile'),
+    ('mako', 'Mako'),
+    ('mason', 'Mason'),
+    ('matlab', 'Matlab'),
+    ('modula2', 'Modula'),
+    ('monkey', 'Monkey'),
+    ('mysql', 'MySQL'),
+    ('numpy', 'NumPy'),
+    ('ocaml', 'OCaml'),
+    ('perl', 'Perl'),
+    ('php', 'PHP'),
+    ('postscript', 'PostScript'),
+    ('powershell', 'PowerShell'),
+    ('prolog', 'Prolog'),
+    ('properties', 'Properties'),
+    ('puppet', 'Puppet'),
+    ('python', 'Python'),
+    ('rb', 'Ruby'),
+    ('rst', 'reStructuredText'),
+    ('rust', 'Rust'),
+    ('sass', 'Sass'),
+    ('scala', 'Scala'),
+    ('scheme', 'Scheme'),
+    ('scilab', 'Scilab'),
+    ('scss', 'SCSS'),
+    ('smalltalk', 'Smalltalk'),
+    ('smarty', 'Smarty'),
+    ('sql', 'SQL'),
+    ('tcl', 'Tcl'),
+    ('tcsh', 'Tcsh'),
+    ('tex', 'TeX'),
+    ('text', 'Text'),
+    ('vb.net', 'VB.net'),
+    ('vim', 'VimL'),
+    ('xml', 'XML'),
+    ('xquery', 'XQuery'),
+    ('xslt', 'XSLT'),
+    ('yaml', 'YAML'),
+)
+

--- a/dpaste/highlight.py
+++ b/dpaste/highlight.py
@@ -1,7 +1,8 @@
 from pygments import highlight
 from pygments.lexers import *
 from pygments.formatters import HtmlFormatter
-from django.conf import settings
+
+from dpaste.conf import settings
 
 """
 # Get a list of all lexer, and then remove all lexer which have '-' or '+'
@@ -22,85 +23,15 @@ LEXER_LIST = sorted(LEXER_LIST)
 
 # The list of lexers. Its not worth to autogenerate this. See above how to
 # retrieve this.
-LEXER_LIST = getattr(settings, 'DPASTE_LEXER_LIST', (
-    ('text', 'Text'),
-    ('text', '----------'),
-    ('abap', 'ABAP'),
-    ('apacheconf', 'ApacheConf'),
-    ('applescript', 'AppleScript'),
-    ('as', 'ActionScript'),
-    ('bash', 'Bash'),
-    ('bbcode', 'BBCode'),
-    ('c', 'C'),
-    ('clojure', 'Clojure'),
-    ('cobol', 'COBOL'),
-    ('css', 'CSS'),
-    ('cuda', 'CUDA'),
-    ('dart', 'Dart'),
-    ('delphi', 'Delphi'),
-    ('diff', 'Diff'),
-    ('django', 'Django'),
-    ('erlang', 'Erlang'),
-    ('fortran', 'Fortran'),
-    ('go', 'Go'),
-    ('groovy', 'Groovy'),
-    ('haml', 'Haml'),
-    ('haskell', 'Haskell'),
-    ('html', 'HTML'),
-    ('http', 'HTTP'),
-    ('ini', 'INI'),
-    ('irc', 'IRC'),
-    ('java', 'Java'),
-    ('js', 'JavaScript'),
-    ('json', 'JSON'),
-    ('lua', 'Lua'),
-    ('make', 'Makefile'),
-    ('mako', 'Mako'),
-    ('mason', 'Mason'),
-    ('matlab', 'Matlab'),
-    ('modula2', 'Modula'),
-    ('monkey', 'Monkey'),
-    ('mysql', 'MySQL'),
-    ('numpy', 'NumPy'),
-    ('ocaml', 'OCaml'),
-    ('perl', 'Perl'),
-    ('php', 'PHP'),
-    ('postscript', 'PostScript'),
-    ('powershell', 'PowerShell'),
-    ('prolog', 'Prolog'),
-    ('properties', 'Properties'),
-    ('puppet', 'Puppet'),
-    ('python', 'Python'),
-    ('rb', 'Ruby'),
-    ('rst', 'reStructuredText'),
-    ('rust', 'Rust'),
-    ('sass', 'Sass'),
-    ('scala', 'Scala'),
-    ('scheme', 'Scheme'),
-    ('scilab', 'Scilab'),
-    ('scss', 'SCSS'),
-    ('smalltalk', 'Smalltalk'),
-    ('smarty', 'Smarty'),
-    ('sql', 'SQL'),
-    ('tcl', 'Tcl'),
-    ('tcsh', 'Tcsh'),
-    ('tex', 'TeX'),
-    ('text', 'Text'),
-    ('vb.net', 'VB.net'),
-    ('vim', 'VimL'),
-    ('xml', 'XML'),
-    ('xquery', 'XQuery'),
-    ('xslt', 'XSLT'),
-    ('yaml', 'YAML'),
-))
+LEXER_LIST = settings.DPASTE_LEXER_LIST
 
 LEXER_KEYS = dict(LEXER_LIST).keys()
 
 # The default lexer is python
-LEXER_DEFAULT = getattr(settings, 'DPASTE_LEXER_DEFAULT', 'python')
+LEXER_DEFAULT = settings.DPASTE_LEXER_DEFAULT
 
 # Lexers which have wordwrap enabled by default
-LEXER_WORDWRAP = getattr(settings, 'DPASTE_LEXER_WORDWRAP', ('text', 'rst'))
+LEXER_WORDWRAP = settings.DPASTE_LEXER_WORDWRAP
 
 
 class NakedHtmlFormatter(HtmlFormatter):

--- a/dpaste/models.py
+++ b/dpaste/models.py
@@ -2,20 +2,15 @@ from random import SystemRandom
 
 from django.db import models
 from django.core.urlresolvers import reverse
-from django.conf import settings
 from django.utils.translation import ugettext_lazy as _
 import mptt
 
+from dpaste.conf import settings
 from dpaste.highlight import LEXER_DEFAULT
 
 R = SystemRandom()
-L = getattr(settings, 'DPASTE_SLUG_LENGTH', 4)
-T = getattr(settings, 'DPASTE_SLUG_CHOICES',
-    'abcdefghijkmnopqrstuvwxyzABCDEFGHJKLMNOPQRSTUVWXYZ1234567890')
 
-ONETIME_LIMIT = getattr(settings, 'DPASTE_ONETIME_LIMIT', 2)
-
-def generate_secret_id(length=L, alphabet=T):
+def generate_secret_id(length=settings.DPASTE_SLUG_LENGTH, alphabet=settings.DPASTE_SLUG_CHOICES):
     return ''.join([R.choice(alphabet) for i in range(length)])
 
 class Snippet(models.Model):
@@ -48,7 +43,7 @@ class Snippet(models.Model):
     @property
     def remaining_views(self):
         if self.expire_type == self.EXPIRE_ONETIME:
-            remaining = ONETIME_LIMIT - self.view_count
+            remaining = settings.DPASTE_ONETIME_LIMIT - self.view_count
             return remaining > 0 and remaining or 0
         return None
 

--- a/dpaste/tests/test_snippet.py
+++ b/dpaste/tests/test_snippet.py
@@ -8,9 +8,9 @@ from django.test.client import Client
 from django.test import TestCase
 from django.test.utils import override_settings
 
+from dpaste.conf import settings
+
 from ..models import Snippet
-from ..forms import EXPIRE_DEFAULT
-from ..highlight import LEXER_DEFAULT
 
 
 class SnippetTestCase(TestCase):
@@ -22,8 +22,8 @@ class SnippetTestCase(TestCase):
     def valid_form_data(self):
         return {
             'content': u"Hello Wörld.\n\tGood Bye",
-            'lexer': LEXER_DEFAULT,
-            'expires': EXPIRE_DEFAULT,
+            'lexer': settings.DPASTE_LEXER_DEFAULT,
+            'expires': settings.DPASTE_EXPIRE_DEFAULT,
         }
 
 

--- a/dpaste/urls/__init__.py
+++ b/dpaste/urls/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 from django.conf.urls import url, patterns, include
 
 urlpatterns = patterns(

--- a/dpaste/urls/dpaste.py
+++ b/dpaste/urls/dpaste.py
@@ -1,7 +1,10 @@
-from django.conf.urls import url, patterns
-from django.conf import settings
+from __future__ import absolute_import
 
-L = getattr(settings, 'DPASTE_SLUG_LENGTH', 4)
+from django.conf.urls import url, patterns
+
+from dpaste.conf import settings
+
+L = settings.DPASTE_SLUG_LENGTH
 
 urlpatterns = patterns('dpaste.views',
     url(r'^about/$', 'about', name='dpaste_about'),

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ django==1.6.1
 django-mptt==0.6.0
 pygments==1.6
 requests==2.0.0
+django-appconf==0.6
 
 # Testing
 python-coveralls==2.4.0


### PR DESCRIPTION
This makes it much easier to view the list of settings,
and avoids repeated calls to `getattr(settings, 'FOO', default)`
that lead to inconsistent default values.

Typically, the DPASTE_MAX_SNIPPETS_PER_USER had two different values in the codebase (10 and 15).
