### PR TITLE
Use https:// for jquery script download by default.

### DIFF
--- a/dpaste/views.py
+++ b/dpaste/views.py
@@ -26,7 +26,7 @@ from .models import ONETIME_LIMIT, Snippet
 template_globals = {
     'site_name': getattr(settings, 'DPASTE_SITE_NAME', 'dpaste.de'),
     'jquery_url': getattr(settings, 'DPASTE_JQUERY_URL',
-        '//ajax.googleapis.com/ajax/libs/jquery/1/jquery.js'),
+        'https://ajax.googleapis.com/ajax/libs/jquery/1/jquery.js'),
 }
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
Google offers SSL for the resource, so we might as well use that
as the default to cut off MITM angles.