### PR TITLE
requirements.txt: use pip valid syntax for django's range.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@
 # -----------------------------------------------------------------------------
 
 # Project dependencies
-django==1.9.*
+django>=1.9.0,<1.10
 django-mptt
 pygments
 requests


### PR DESCRIPTION
Using 1.9.* doesn't work for any pip/requirements.txt aware code I know of;
however, using this syntax works for pip and is equivalent in intent.