### PR TITLE
#85: Work around mptt slowness when there are thousands of snippets.

### DIFF
--- a/dpaste/models.py
+++ b/dpaste/models.py
@@ -69,6 +69,15 @@ class Snippet(models.Model):
     def save(self, *args, **kwargs):
         if not self.secret_id:
             self.secret_id = generate_secret_id()
+        # Work around performance issues in mptt when dealing with a large number
+        # of trees; note that this is inherintly race, but so is mptt's manager.
+        # We're just short circuiting the invocation so it's not fill in gaps
+        # in the tree_id space.  See ticket #85 for further discussion.
+        if self.parent is None  and self.parent_id is None and self.pk is None:
+            self.lft = 1
+            self.rght = 2
+            self.level = 1
+            self.tree_id = self._tree_manager._get_next_tree_id()
         super(Snippet, self).save(*args, **kwargs)
 
     def get_absolute_url(self):


### PR DESCRIPTION
See ticket #85 for an example test case.

This works around mptt slowness via providing the proper defaults
settings, and using the mptt manager to track down the next tree_id
to use.  Note that it's inherintly racey in finding the next tree_id-
this isn't a flaw of this code, it's a flaw of mptt.  If you trace
the _get_next_tree_id() functionality, you'll find that it assumes
that between when that value is computed, and when the insertion happens,
nothing else slipped in- this isn't a safe assumption, although the
timing required to trigger the issue would be fairly tight.