### PR TITLE
Fix whitespace pre support, remove mptt

### DIFF
--- a/dpaste/templates/dpaste/snippet_details.html
+++ b/dpaste/templates/dpaste/snippet_details.html
@@ -70,9 +70,11 @@
     Snippet
     ======================================================================= -->
     {% if snippet.lexer == 'text' %}
-    <div class="snippet-rendered">
-        {{ snippet.content|linebreaksbr }}
-    </div>
+    {% comment %}
+    Note that the interpolation of snippet_content needs to be a single line- downstream may be
+    using styling that converts snippet-rendered to an effective pre to preserve whitespace indentation.
+    {% endcomment %}
+    <div class="snippet-rendered">{{ snippet.content|linebreaksbr }}</div>
     {% else %}
         {% include "dpaste/snippet_pre.html" %}
     {% endif %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@
 
 # Project dependencies
 django>=1.10
-django-mptt
 pygments
 requests
 


### PR DESCRIPTION
mptt is obvious, but for whitespace, I'll refer to my commit message.  Note, you may wish to just change the snippet-rendered class to have {whitespace:pre} anyways- it seems like a default has less of a potential to surprise users.

If someone posts python code, but labels it as text- say something like thus:
```
if blah:
  print "me!"
```

dpaste was rendering that as
```
if blah
print "me!"
```

We may wish to make the snippet-rendered class have {whitespace: pre} styling;
regardless if dpaste chooses to do so, this change is necessary so any end
consumers can set the styling themselves; to support that, any extra indentation
the template adds must be suppressed.