### PR TITLE
Replace leading spaces with &nbsp; in HTML so they dont get lost

### DIFF
--- a/dpaste/highlight.py
+++ b/dpaste/highlight.py
@@ -121,7 +121,7 @@ class NakedHtmlFormatter(HtmlFormatter):
             yield i, t
 
 def pygmentize(code_string, lexer_name=LEXER_DEFAULT):
-    # Plain code is noth hihglighted
+    # Plain code is not highlighted
     if lexer_name == PLAIN_CODE:
         return '\n'.join([u'<span class="nn">{}</span>'.format(escape(l))
             for l in code_string.splitlines()])

--- a/dpaste/templatetags/dpaste_tags.py
+++ b/dpaste/templatetags/dpaste_tags.py
@@ -11,6 +11,10 @@ def in_list(value, arg):
 @register.filter
 def highlight(snippet):
     h = pygmentize(snippet.content, snippet.lexer)
-    h = h.replace(u'  ', u'&nbsp;&nbsp;')
     h = h.replace(u'\t', '&nbsp;&nbsp;&nbsp;&nbsp;')
+
+    # see https://github.com/bartTC/dpaste/issues/88
+    h = h.replace(u' ', u'&nbsp;')
+    h = h.replace(u'<span&nbsp;class', u'<span class')
+
     return h.splitlines()


### PR DESCRIPTION
This is a suggested solution for https://github.com/bartTC/dpaste/issues/88

The approach I took is to replace all the spaces in the HTML that pygmentize returns, with `&nbsp;`
A side effect of this approach is that it puts non-breaking spaces inside the `<span>` tags as well, i.e. `<span&nbsp;class="x">no&nbsp;spaces</span>`.
Therefore I then replace all `<span&nbsp;class` with `<span class`.
It feels a bit dirty, but I think it helps keep things simple.

More information below on the approaches I tried.
<br>
<br>

**More Information**
It looks like we're at the mercy of Pygments a bit here. I've observed two different cases so far. Let's take the following code snippet:
```
no spaces
 one space
  two spaces
```
 1. Using the Python lexer, pygmentizing the above snippet gives us:
```
<div class="code python">
  <ol>
    <li id="1"><span class="n">no</span> <span class="n">spaces</span></li>
    <li id="2"> <span class="n">one</span> <span class="n">space</span></li>
    <li id="3">&nbsp;&nbsp;<span class="n">two</span> <span class="n">spaces</span></li>
  </ol>
</div>
```
 2. Using the Django lexer, pygmentizing the original snippet returns:
```
<div class="code django">
  <ol>
    <li id="1"><span class="x">no spaces</span></li>
    <li id="2"><span class="x"> one space</span></li>
    <li id="3"><span class="x">&nbsp;&nbsp;two spaces</span></li>
  </ol>
</div>
```
My first thought was to replace all `" "` with `&nbsp;`. Although this seems to still render correctly on the page, it is not valid HTML. Notice the `&nbsp;` inside the `<span>` tag below:
```
<div class="code django">
  <ol>
    <li id="1"><span&nbsp;class="x">no&nbsp;spaces</span></li>
    <li id="2"><span&nbsp;class="x">&nbsp;one&nbsp;space</span></li>
    <li id="3"><span&nbsp;class="x">&nbsp;&nbsp;two&nbsp;spaces</span></li>
  </ol>
</div>
```

My second thought then was to replace all ` <span` with `&nbsp;<span`.

This works for the case of the Python lexer (number 1 above). However it does not work for the Django lexer (number 2 above). Notice the difference between what pygmentize returns for Python and Django above. In number 1 (Python), the leading space comes before the ` <span>`, whereas in number 2 (Django) the leading space comes after the `<span> `. I believe this is the work of Pygments, not something we're doing.

Therefore to keep things simple, I revert back to my first approach. Replacing all spaces with `&nbsp;`. However I need to remove the `&nbsp;` from `<span&nbsp;class>` so that it becomes valid HTML. So I replace `<span&nbsp;class` with `<span class`. It feels dirty but I think it keeps things simple.