### PR TITLE
Minor fixes

### DIFF
--- a/dpaste/forms.py
+++ b/dpaste/forms.py
@@ -66,7 +66,7 @@ class SnippetForm(forms.ModelForm):
 
     def clean_content(self):
         content = self.cleaned_data.get('content', '')
-        if content.strip() == '':
+        if not content.strip():
             raise forms.ValidationError(_('This field is required.'))
         return content
 

--- a/dpaste/highlight.py
+++ b/dpaste/highlight.py
@@ -114,8 +114,7 @@ class NakedHtmlFormatter(HtmlFormatter):
         return self._wrap_code(source)
 
     def _wrap_code(self, source):
-        for i, t in source:
-            yield i, t
+        yield from source
 
 
 class PlainCodeHighlighter(Highlighter):

--- a/dpaste/views.py
+++ b/dpaste/views.py
@@ -257,7 +257,7 @@ class APIView(View):
                 lexer = config.PLAIN_CODE_SYMBOL
 
         if expires:
-            expire_options = [str(i) for i in dict(config.EXPIRE_CHOICES).keys()]
+            expire_options = [str(i) for i in dict(config.EXPIRE_CHOICES)]
             if expires not in expire_options:
                 return HttpResponseBadRequest(
                     'Invalid expire choice "{}" given. Valid values are: {}'.format(


### PR DESCRIPTION
This pull request suggest following 3 changes,

1. `if content.strip() == ''` is replaced with `if not content.strip()` which is more pythonic.
2. Since the minimum python version required for dpaste is 3.4 we could replace the explicit `for` loop  
    ```
        for i, t in source:
            yield i, t
    ```

    with `yield from` syntax. i.e. `yield from source`(Available from python 3.3 onwards)


3. There is no need to call `keys` here as the iteration over the  `dict` yields  its keys. 

 
    ``` 
    expire_options = [str(i) for i in dict(config.EXPIRE_CHOICES).keys()]
    ```
