### PR TITLE
Use CTRL+Enter on Linux

### DIFF
--- a/client/js/dpaste.js
+++ b/client/js/dpaste.js
@@ -3,8 +3,8 @@
 // -----------------------------------------------------------------------------
 // Add data-platform to the body tag to show platform related shortcuts
 // -----------------------------------------------------------------------------
-const isWindows = navigator.appVersion.indexOf('Win') !== -1;
-document.body.dataset.platform = isWindows ? 'win' : 'mac';
+const isMac = navigator.platform.indexOf('Mac') !== -1;
+document.body.dataset.platform = isMac ? 'mac' : 'win';
 
 // -----------------------------------------------------------------------------
 // Autofocus the content field on the homepage
@@ -18,7 +18,7 @@ if (af !== null) {
 // Cmd+Enter or Ctrl+Enter submits the form
 // -----------------------------------------------------------------------------
 document.body.onkeydown = function(e) {
-  const metaKey = isWindows ? e.ctrlKey : e.metaKey;
+  const metaKey = isMac ? e.metaKey : e.ctrlKey;
   const form = document.querySelector('.snippet-form');
 
   if (form && e.keyCode === 13 && metaKey) {


### PR DESCRIPTION
Currently, there's only "Windows and "not Windows", which makes all non-Windows platforms behave like Mac (i.e., they have a meta key.). That's unfortunately not very true.

Instead, I'd suggest use the apple meta key on platforms that are known to be Mac and support CTRL+Enter on all other platforms (Linux, Unix, etc.)

This is related to #33, which I filed almost six years ago. Wow.